### PR TITLE
Added a prompt before closing SteamVR

### DIFF
--- a/k2vr-installer-gui/Tools/Utils.cs
+++ b/k2vr-installer-gui/Tools/Utils.cs
@@ -26,12 +26,16 @@ namespace k2vr_installer_gui.Tools
                 //Ask if SteamVR should be closed
                 if (MessageBox.Show(
                     "SteamVR needs to be closed to continue the installation." + Environment.NewLine + "Do you want Setup to close SteamVR?",
-                    "Please close SteamVR",
+                    "Close SteamVR?",
                     MessageBoxButton.YesNo,
                     MessageBoxImage.Warning
                     ) != MessageBoxResult.Yes)
                 {
-                    return false;
+                    //Only exit if SteamVR is still running
+                    if (Process.GetProcesses().FirstOrDefault((Process proc) => proc.ProcessName == "vrserver" || proc.ProcessName == "vrserver") != null)
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/k2vr-installer-gui/Tools/Utils.cs
+++ b/k2vr-installer-gui/Tools/Utils.cs
@@ -24,6 +24,7 @@ namespace k2vr_installer_gui.Tools
             //Check if SteamVR is running
             if (Process.GetProcesses().FirstOrDefault((Process proc) => proc.ProcessName == "vrserver" || proc.ProcessName == "vrmonitor") == null)
             {
+                Logger.Log("Done!");
                 return true;
             }
 
@@ -36,7 +37,13 @@ namespace k2vr_installer_gui.Tools
                 ) != MessageBoxResult.Yes)
             {
                 //Only exit setup if SteamVR is still running after choosing "No"
-                return (Process.GetProcesses().FirstOrDefault((Process proc) => proc.ProcessName == "vrserver" || proc.ProcessName == "vrmonitor") == null);
+                if (Process.GetProcesses().FirstOrDefault((Process proc) => proc.ProcessName == "vrserver" || proc.ProcessName == "vrmonitor") == null)
+                {
+                    Logger.Log("Done!");
+                    return true;
+                }
+                MessageBox.Show("SteamVR needs to be closed to install KinectToVR!" + Environment.NewLine + "Restart this installer to try again.", "Close SteamVR", MessageBoxButton.OK, MessageBoxImage.Error);
+                return false;
             }
 
 

--- a/k2vr-installer-gui/Tools/Utils.cs
+++ b/k2vr-installer-gui/Tools/Utils.cs
@@ -21,28 +21,29 @@ namespace k2vr_installer_gui.Tools
         {
             Logger.Log("Checking if SteamVR is open...", false);
 
-            if (Process.GetProcesses().FirstOrDefault((Process proc) => proc.ProcessName == "vrserver" || proc.ProcessName == "vrserver") != null)
+            //Check if SteamVR is running
+            if (Process.GetProcesses().FirstOrDefault((Process proc) => proc.ProcessName == "vrserver" || proc.ProcessName == "vrmonitor") == null)
             {
-                //Ask if SteamVR should be closed
-                if (MessageBox.Show(
-                    "SteamVR needs to be closed to continue the installation." + Environment.NewLine + "Do you want Setup to close SteamVR?",
-                    "Close SteamVR?",
-                    MessageBoxButton.YesNo,
-                    MessageBoxImage.Warning
-                    ) != MessageBoxResult.Yes)
-                {
-                    //Only exit if SteamVR is still running
-                    if (Process.GetProcesses().FirstOrDefault((Process proc) => proc.ProcessName == "vrserver" || proc.ProcessName == "vrserver") != null)
-                    {
-                        return false;
-                    }
-                }
+                return true;
             }
+
+            //Ask if SteamVR should be closed
+            if (MessageBox.Show(
+                "SteamVR needs to be closed to continue the installation." + Environment.NewLine + "Do you want Setup to close SteamVR?",
+                "Close SteamVR?",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Warning
+                ) != MessageBoxResult.Yes)
+            {
+                //Only exit setup if SteamVR is still running after choosing "No"
+                return (Process.GetProcesses().FirstOrDefault((Process proc) => proc.ProcessName == "vrserver" || proc.ProcessName == "vrmonitor") == null);
+            }
+
 
             //Close VrMonitor
             foreach (Process process in Process.GetProcesses().Where((proc) => proc.ProcessName == "vrmonitor"))
             {
-                Logger.Log("Closing vrmonitor (PID: " + process.Id + ")...", false);
+                Logger.Log("Closing vrmonitor...", false);
 
                 process.CloseMainWindow();
                 Thread.Sleep(5000);
@@ -62,7 +63,7 @@ namespace k2vr_installer_gui.Tools
                so we close that, if it's open as well (monitor will complain if you close server first) */
             foreach (Process process in Process.GetProcesses().Where((proc) => proc.ProcessName == "vrserver"))
             {
-                Logger.Log("Closing vrserver (PID: " + process.Id + ")...", false);
+                Logger.Log("Closing vrserver...", false);
 
                 // CloseMainWindow won't work here because it doesn't have a window
                 process.Kill(); 


### PR DESCRIPTION
Added a prompt asking whether the setup should close SteamVR when it detects that SteamVR is running.

This prevents the user from being thrown out of the game without warning and gives them a chance to shut down SteamVR gracefully.