### PR TITLE
Prevent device detection exceptions from halting the installer

### DIFF
--- a/k2vr-installer-gui/Tools/InstallerState.cs
+++ b/k2vr-installer-gui/Tools/InstallerState.cs
@@ -5,12 +5,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Management;
 using System.Windows;
-using System.Windows.Documents;
 using System.Xml.Serialization;
 
 namespace k2vr_installer_gui.Tools
 {
-    public class InstallerState
+	public class InstallerState
     {
         public const string fileName = "installerSettings.xml";
 
@@ -109,7 +108,10 @@ namespace k2vr_installer_gui.Tools
                     devices.Dispose();
                 }
             }
-            catch (Exception) { }
+            catch (Exception e)
+            {
+                Logger.Log($"Failed to detect a Kinect! Continuing anyway...");
+            }
         }
 
         public void UpdateSdkInstalled()

--- a/k2vr-installer-gui/Tools/InstallerState.cs
+++ b/k2vr-installer-gui/Tools/InstallerState.cs
@@ -79,12 +79,12 @@ namespace k2vr_installer_gui.Tools
 
         public void UpdatePluggedInDevice()
         {
-            using (var searcher = new ManagementObjectSearcher(@"Select * From Win32_USBControllerDevice"))
+            try
             {
-                ManagementObjectCollection devices = searcher.Get();
-                foreach (ManagementBaseObject device in devices)
+                using (var searcher = new ManagementObjectSearcher(@"Select * From Win32_USBControllerDevice"))
                 {
-                    try
+                    ManagementObjectCollection devices = searcher.Get();
+                    foreach (ManagementBaseObject device in devices)
                     {
                         string dependent = (string)device.GetPropertyValue("Dependent");
                         string devId = dependent.Substring(dependent.IndexOf("DeviceID=\""));
@@ -106,10 +106,10 @@ namespace k2vr_installer_gui.Tools
                             pluggedInDevice = TrackingDevice.XboxOneKinect;
                         }
                     }
-                    catch (ManagementException) { }
+                    devices.Dispose();
                 }
-                devices.Dispose();
             }
+            catch (Exception) { }
         }
 
         public void UpdateSdkInstalled()

--- a/k2vr-installer-gui/Uninstall/Uninstaller.cs
+++ b/k2vr-installer-gui/Uninstall/Uninstaller.cs
@@ -262,12 +262,13 @@ namespace k2vr_installer_gui.Uninstall
                     if (uninstallFromSettings)
                     {
                         File.Delete(Path.Combine(path, InstallerState.fileName));
-                        string confSettingsPath = Path.Combine(path, "ConfigSettings.cfg");
+                        string confSettingsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "KinectToVR", "ConfigSettings.cfg");
                         if (File.Exists(confSettingsPath) && MessageBox.Show(Properties.Resources.install_calibration_remove.Replace("{0}", path),
                             Properties.Resources.install_calibration_remove_title, MessageBoxButton.YesNo) == MessageBoxResult.Yes)
                         {
                             File.Delete(confSettingsPath);
                         }
+
                         string[] files = Directory.GetFiles(path);
                         string[] directories = Directory.GetDirectories(path);
                         if (directories.Length == 0 && files.Length == 1 && files[0] == Path.Combine(path, "k2vr-installer-gui.exe"))

--- a/k2vr-installer-gui/Uninstall/Uninstaller.cs
+++ b/k2vr-installer-gui/Uninstall/Uninstaller.cs
@@ -262,12 +262,14 @@ namespace k2vr_installer_gui.Uninstall
                     if (uninstallFromSettings)
                     {
                         File.Delete(Path.Combine(path, InstallerState.fileName));
-                        string confSettingsPath = Path.Combine(path, "ConfigSettings.cfg");
+
+                        string confSettingsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "KinectToVR", "ConfigSettings.cfg");
                         if (File.Exists(confSettingsPath) && MessageBox.Show(Properties.Resources.install_calibration_remove.Replace("{0}", path),
                             Properties.Resources.install_calibration_remove_title, MessageBoxButton.YesNo) == MessageBoxResult.Yes)
                         {
                             File.Delete(confSettingsPath);
                         }
+
                         string[] files = Directory.GetFiles(path);
                         string[] directories = Directory.GetDirectories(path);
                         if (directories.Length == 0 && files.Length == 1 && files[0] == Path.Combine(path, "k2vr-installer-gui.exe"))

--- a/k2vr-installer-gui/Uninstall/Uninstaller.cs
+++ b/k2vr-installer-gui/Uninstall/Uninstaller.cs
@@ -262,14 +262,12 @@ namespace k2vr_installer_gui.Uninstall
                     if (uninstallFromSettings)
                     {
                         File.Delete(Path.Combine(path, InstallerState.fileName));
-
-                        string confSettingsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "KinectToVR", "ConfigSettings.cfg");
+                        string confSettingsPath = Path.Combine(path, "ConfigSettings.cfg");
                         if (File.Exists(confSettingsPath) && MessageBox.Show(Properties.Resources.install_calibration_remove.Replace("{0}", path),
                             Properties.Resources.install_calibration_remove_title, MessageBoxButton.YesNo) == MessageBoxResult.Yes)
                         {
                             File.Delete(confSettingsPath);
                         }
-
                         string[] files = Directory.GetFiles(path);
                         string[] directories = Directory.GetDirectories(path);
                         if (directories.Length == 0 && files.Length == 1 && files[0] == Path.Combine(path, "k2vr-installer-gui.exe"))


### PR DESCRIPTION
Fixes issue #8, and makes device detection exceptions not crash the installer.