### PR TITLE
Improve SteamVR folder detection

### DIFF
--- a/k2vr-installer-gui/Tools/InstallerState.cs
+++ b/k2vr-installer-gui/Tools/InstallerState.cs
@@ -9,7 +9,7 @@ using System.Xml.Serialization;
 
 namespace k2vr_installer_gui.Tools
 {
-	public class InstallerState
+    public class InstallerState
     {
         public const string fileName = "installerSettings.xml";
 
@@ -132,7 +132,7 @@ namespace k2vr_installer_gui.Tools
         {
             steamPath = "";
             steamPath = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Valve\Steam", "InstallPath", "").ToString();
-            if (steamPath == "")
+            if (!Directory.Exists(steamPath))
             {
                 MessageBox.Show("Steam installation folder not found!" + Environment.NewLine +
                     "Are you sure it is installed?" + Environment.NewLine +
@@ -141,8 +141,29 @@ namespace k2vr_installer_gui.Tools
                 return;
             }
 
-            steamVrPath = "";
-            vrPathReg = "";
+            // If SteamVR is installed, it should be registered as an uninstallable application
+            steamVrPath = (string) Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 250820", "InstallLocation", "") ?? "";
+            vrPathReg = Path.Combine(steamVrPath, "bin", "win64", "vrpathreg.exe");
+
+            if (!Directory.Exists(steamVrPath))
+            {
+                MessageBox.Show("SteamVR installation folder not found!" + Environment.NewLine +
+                                "Are you sure it is installed?" + Environment.NewLine +
+                                "If you are, please join our Discord server for further assistance (link on www.k2vr.tech)");
+                Application.Current.Shutdown(1);
+                return;
+            }
+
+            if (!File.Exists(OpenVrPaths.path))
+            {
+                MessageBox.Show("OpenVRPaths not found!" + Environment.NewLine +
+                                "Have you launched SteamVR before?" + Environment.NewLine +
+                                "If so, please join our Discord server for further assistance (link on www.k2vr.tech)");
+                Application.Current.Shutdown(1);
+                return;
+            }
+
+            /*
             try
             {
                 var openVrPaths = OpenVrPaths.Read();
@@ -165,6 +186,7 @@ namespace k2vr_installer_gui.Tools
                 Application.Current.Shutdown(1);
                 return;
             }
+
             if (vrPathReg == "")
             {
                 MessageBox.Show("VRPathReg not found!" + Environment.NewLine +
@@ -172,6 +194,7 @@ namespace k2vr_installer_gui.Tools
                 Application.Current.Shutdown(1);
                 return;
             }
+            */
 
             steamVrSettingsPath = Path.Combine(steamPath, "config", "steamvr.vrsettings");
             copiedDriverPath = Path.Combine(steamVrPath, "drivers", "KinectToVR");

--- a/k2vr-installer-gui/Tools/OpenVRFiles/OpenVrPaths.cs
+++ b/k2vr-installer-gui/Tools/OpenVRFiles/OpenVrPaths.cs
@@ -6,7 +6,7 @@ namespace k2vr_installer_gui.Tools.OpenVRFiles
 {
     class OpenVrPaths
     {
-        static string path = Environment.ExpandEnvironmentVariables(Path.Combine("%LocalAppData%", "openvr", "openvrpaths.vrpath"));
+        public static string path = Environment.ExpandEnvironmentVariables(Path.Combine("%LocalAppData%", "openvr", "openvrpaths.vrpath"));
 
         // Prevent Warning CS0649: Field '...' is never assigned to, and will always have its default value null:
 #pragma warning disable 0649

--- a/k2vr-installer-gui/Uninstall/Uninstaller.cs
+++ b/k2vr-installer-gui/Uninstall/Uninstaller.cs
@@ -230,6 +230,14 @@ namespace k2vr_installer_gui.Uninstall
         public static void UnregisterK2EX(string path)
         {
             string driverPath = path + @"\KinectToVR";
+            if (!File.Exists(App.state.vrPathReg))
+            {
+                MessageBox.Show("SteamVR installation folder not found or corrupt!" + Environment.NewLine +
+                                "Try verifying your SteamVR install's integrity, or reinstalling it." + Environment.NewLine +
+                                "If none of these work, please join our Discord server for further assistance (link on www.k2vr.tech)");
+                Application.Current.Shutdown(1);
+                return;
+            }
             Process.Start(App.state.vrPathReg, "removedriver \"" + driverPath + "\"").WaitForExit();
 
             var openVrPaths = OpenVrPaths.Read();

--- a/k2vr-installer-gui/k2vr-installer-gui.csproj
+++ b/k2vr-installer-gui/k2vr-installer-gui.csproj
@@ -245,7 +245,6 @@
     <Resource Include="installer-icon.png" />
     <Resource Include="Pages\cover.png" />
     <Resource Include="installer-icon.ico" />
-    <Content Include="Resources\Jost-600-Semi.ttf" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />


### PR DESCRIPTION
This PR searches for the SteamVR install directory using the uninstaller entry and guesses if this fails. Its however not bulletproof in every situation yet.